### PR TITLE
fix: Push back minimal VSCode version to 1.77.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/glob": "^8.1.0",
         "@types/node": "^20.11.4",
         "@types/semver": "^7.5.6",
-        "@types/vscode": "^1.85.0",
+        "@types/vscode": "^1.77.0",
         "@types/ws": "^8.5.10",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
@@ -51,7 +51,7 @@
         "ws": "^8.16.0"
       },
       "engines": {
-        "vscode": "^1.85.0"
+        "vscode": "^1.77.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/MilanKovacic/vitest-visual-studio-code-extension/issues"
   },
   "engines": {
-    "vscode": "^1.85.0"
+    "vscode": "^1.77.0"
   },
   "categories": [
     "Testing"
@@ -172,7 +172,7 @@
     "@types/glob": "^8.1.0",
     "@types/node": "^20.11.4",
     "@types/semver": "^7.5.6",
-    "@types/vscode": "^1.85.0",
+    "@types/vscode": "^1.77.0",
     "@types/ws": "^8.5.10",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",


### PR DESCRIPTION
We should update the minimal VSCode version only if needed. That way we can support more users running older builds of VsCode.